### PR TITLE
feat(vscode): extenstionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "Linters",
     "Formatters"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "keywords": [
     "solidity",
     "ethereum",


### PR DESCRIPTION
`extensionKind` is a property in the extension manifest. It allows extensions to specify a preferred running location. That can be the machine that has the workspace (workspace) or the user interface (ui). If an extension can run on both, it can specify an order of preference. 

[see https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location](https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location)

<!--
Thank you for using **Hardhat for Visual Studio Code** and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

# enable `extensionKind` field in package manifest 

TLDR: this allows this extension to be used in devcontainers / remote developer environments 

[read more about this setting via the vscode docs](https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location)